### PR TITLE
Update geodb.service.ts

### DIFF
--- a/projects/wft-geodb-angular-client/src/lib/geodb.service.ts
+++ b/projects/wft-geodb-angular-client/src/lib/geodb.service.ts
@@ -240,7 +240,7 @@ export class GeoDbService {
     // Workaround for HttpClient '+' encoding bug.
     const locationId = GeoDbService
       .toLocationString(request.location)
-      .replace('+', '%2B');
+      .replaceAll('+', '%2B');
 
     const endpoint = this.placesEndpoint + '?location=' + locationId;
 


### PR DESCRIPTION
.replace only replace the first match. And when the string containing two + then the server response with bad request.